### PR TITLE
Allow specifying a webmixer class to use when creating ricecooker topic tree

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,15 +71,21 @@ Ready to be uploaded via Ricecooker to Studio or used in Kolibri.
 Args:
 
 - `license` - License to apply to content nodes.
-- `imscp_dict` - IMSCP topic tree dict from `extract_from_zip` or `extract_from_dir`.
+- `imscp_dict` - Dict of IMSCP from `extract_from_zip` or `extract_from_dir`.
+- `ims_dir (string)` - Path of directory of IMSCP
+- `scraper_class (webmixer.HTMLPageScraper class, optional)` - Webmixer scraper class to use for pruning an HTML page.
+- `temp_dir (string, optional)` - Full path of temporary directory to output HTML zip files to.
 
-Sample usage:
+Sample usage with Webmixer:
 
 ```
+from webmixer.scrapers.pages.base import DefaultScraper
+
 channel = self.get_channel()
 imscp_dict = extract_from_dir('eventos', license)
 for topic_dict in imscp_dict['organizations']:
-    topic_tree = make_topic_tree(license, topic_dict)
+    topic_tree = make_topic_tree(license, topic_dict, 'eventos',
+        scraper_class=DefaultScraper)
     channel.add_child(topic_tree)
 ```
 

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Return a TopicTree node from a dict of some subset of an IMSCP manifest.
 
 Ready to be uploaded via Ricecooker to Studio or used in Kolibri.
 
-By default, this will take the entire IMS directory and use that for each app uploaded. (Some imsmanifest.xml don't completely specify all required dependencies.) However, you can specify a Webmixer class to use, to use Webmixer to determine which files are needed and just package those with the app.
+By default, for each HTML app, this will package together files that the imsmanifest.xml specifies as its required files and dependencies. You can also specify a Webmixer class to use, to use Webmixer to determine which files are needed and package those with the app. This will ignore specified required files from the manifest.
 
 Args:
 

--- a/README.md
+++ b/README.md
@@ -68,6 +68,8 @@ Return a TopicTree node from a dict of some subset of an IMSCP manifest.
 
 Ready to be uploaded via Ricecooker to Studio or used in Kolibri.
 
+By default, this will take the entire IMS directory and use that for each app uploaded. (Some imsmanifest.xml don't completely specify all required dependencies.) However, you can specify a Webmixer class to use, to use Webmixer to determine which files are needed and just package those with the app.
+
 Args:
 
 - `license` - License to apply to content nodes.

--- a/examples/educalab_chef.py
+++ b/examples/educalab_chef.py
@@ -30,7 +30,7 @@ class SampleEducalabChef(SushiChef):
     """
     channel_info = {
         'CHANNEL_SOURCE_DOMAIN': "sample-imscp.procomun.educalab.es",
-        'CHANNEL_SOURCE_ID': "sample-imscp-procomun-educalab",
+        'CHANNEL_SOURCE_ID': "sample-imscp-procomun-educalab-no-webmixer",
         'CHANNEL_TITLE': "Sample IMSCP upload from procomun.educalab.es",
         'CHANNEL_DESCRIPTION': "Sample Sushi Chef that uses the IMSCP library to upload a channel from procomun.educalab.es",
         'CHANNEL_LANGUAGE': "es",
@@ -50,8 +50,7 @@ class SampleEducalabChef(SushiChef):
             imscp_dict = extract_from_zip('examples/eventos.zip', license,
                     extract_path)
             for topic_dict in imscp_dict['organizations']:
-                topic_tree = make_topic_tree(license, topic_dict, extract_path,
-                        scraper_class=DefaultScraper)
+                topic_tree = make_topic_tree(license, topic_dict, extract_path)
                 print('Adding topic tree to channel:', topic_tree)
                 channel.add_child(topic_tree)
 

--- a/examples/educalab_chef.py
+++ b/examples/educalab_chef.py
@@ -16,6 +16,7 @@ import tempfile
 
 from ricecooker.chefs import SushiChef
 from ricecooker.classes import licenses
+from webmixer.scrapers.pages.base import DefaultScraper
 
 from imscp import extract_from_zip
 from ricecooker_utils import make_topic_tree
@@ -46,9 +47,11 @@ class SampleEducalabChef(SushiChef):
         logging.basicConfig(level=logging.INFO)
 
         with tempfile.TemporaryDirectory() as extract_path:
-            imscp_dict = extract_from_zip('examples/eventos.zip', license, extract_path)
+            imscp_dict = extract_from_zip('examples/eventos.zip', license,
+                    extract_path)
             for topic_dict in imscp_dict['organizations']:
-                topic_tree = make_topic_tree(license, topic_dict)
+                topic_tree = make_topic_tree(license, topic_dict, extract_path,
+                        scraper_class=DefaultScraper)
                 print('Adding topic tree to channel:', topic_tree)
                 channel.add_child(topic_tree)
 

--- a/examples/gitta_chef.py
+++ b/examples/gitta_chef.py
@@ -13,6 +13,7 @@ import tempfile
 
 from ricecooker.chefs import SushiChef
 from ricecooker.classes import licenses
+from webmixer.scrapers.pages.base import DefaultScraper
 
 from imscp import extract_from_zip
 from ricecooker_utils import make_topic_tree
@@ -47,7 +48,9 @@ class SampleGittaChef(SushiChef):
             imscp_dict = extract_from_zip(
                     'examples/gitta_ims.zip', license, extract_path)
             for topic_dict in imscp_dict['organizations']:
-                topic_tree = make_topic_tree(license, topic_dict, extract_path)
+                topic_tree = make_topic_tree(license, topic_dict,
+                        extract_path, scraper_class=DefaultScraper,
+                        temp_dir=kwargs.get('temp_dir'))
                 print('Adding topic tree to channel:', topic_tree)
                 channel.add_child(topic_tree)
 
@@ -62,5 +65,6 @@ if __name__ == '__main__':
     """
     This code will run when the sushi chef is called from the command line.
     """
-    chef = SampleGittaChef()
-    chef.main()
+    with tempfile.TemporaryDirectory() as temp_dir:
+        chef = SampleGittaChef(temp_dir=temp_dir)
+        chef.main()

--- a/imscp.py
+++ b/imscp.py
@@ -49,7 +49,9 @@ def extract_from_dir(ims_dir, license):
     logging.info('Extracting tree structure ...\n')
 
     metadata_elem = manifest_root.find('metadata', nsmap)
-    metadata = collect_metadata(metadata_elem)
+    metadata = {}
+    if metadata_elem is not None:
+        metadata = collect_metadata(metadata_elem)
 
     resources_elem = manifest_root.find('resources', nsmap)
     resources_dict = dict((r.get('identifier'), r) for r in resources_elem)
@@ -94,7 +96,8 @@ def collect_metadata(metadata_elem):
 
     for tag in ('general', 'rights', 'educational', 'lifecycle'):
         elem = metadata_elem.find('lom/%s' % tag)
-        metadata_dict.update(xmltodict.parse(etree.tostring(elem)))
+        if elem:
+            metadata_dict.update(xmltodict.parse(etree.tostring(elem)))
 
     return metadata_dict
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 lxml==4.4.1
 ricecooker>=0.6.33
 xmltodict==0.12.0
+webmixer>=0.0.1

--- a/ricecooker_utils.py
+++ b/ricecooker_utils.py
@@ -1,6 +1,8 @@
 from distutils.dir_util import copy_tree
+import hashlib
 import logging
 import os
+import pathlib
 import shutil
 import tempfile
 
@@ -9,7 +11,8 @@ from ricecooker.utils.zip import create_predictable_zip
 from ricecooker.utils.browser import preview_in_browser
 
 
-def make_topic_tree(license, imscp_dict, ims_dir):
+def make_topic_tree(license, imscp_dict, ims_dir, scraper_class=None,
+        temp_dir=None):
     """Return a TopicTree node from a dict of some subset of an IMSCP manifest.
 
     Ready to be uploaded via Ricecooker to Studio or used in Kolibri.
@@ -17,6 +20,11 @@ def make_topic_tree(license, imscp_dict, ims_dir):
     Args:
         license - License to apply to content nodes.
         imscp_dict - Dict of IMSCP from extract_from_zip or extract_from_dir.
+        ims_dir (string) - Path of directory of IMSCP
+        scraper_class (webmixer.HTMLPageScraper class, optional):
+            Webmixer scraper class to use for pruning an HTML page.
+        temp_dir (string, optional) - Full path of temporary directory to
+            output HTML zip files to.
     """
     if imscp_dict.get('children'):
         topic_node = nodes.TopicNode(
@@ -24,42 +32,54 @@ def make_topic_tree(license, imscp_dict, ims_dir):
             title=imscp_dict['title']
         )
         for child in imscp_dict['children']:
-            topic_node.add_child(make_topic_tree(license, child, ims_dir))
+            topic_node.add_child(make_topic_tree(
+                    license, child, ims_dir, scraper_class=scraper_class,
+                    temp_dir=temp_dir))
         return topic_node
     else:
         if imscp_dict['type'] == 'webcontent':
-            return create_html5_app_node(license, imscp_dict, ims_dir)
+            return create_html5_app_node(license, imscp_dict, ims_dir,
+                    scraper_class=scraper_class, temp_dir=temp_dir)
         else:
             logging.warning(
                     'Content type %s not supported yet.' % imscp_dict['type'])
 
 
-def create_html5_app_node(license, content_dict, ims_dir):
-    with tempfile.TemporaryDirectory() as destination:
-        index_copy_path = os.path.join(destination, 'index.html')
-        destination_src = os.path.join(destination, 'imscp')
+def create_html5_app_node(license, content_dict, ims_dir, scraper_class=None,
+        temp_dir=None):
+    if scraper_class:
+        index_path = os.path.join(ims_dir, content_dict['index_file'])
+        index_uri = pathlib.Path(os.path.abspath(index_path)).as_uri()
+        zip_name = '%s.zip' % hashlib.md5(index_uri.encode('utf-8')).hexdigest()
+        temp_dir = temp_dir if temp_dir else tempfile.gettempdir()
+        zip_path = os.path.join(temp_dir, zip_name)
+        scraper = scraper_class(index_uri)
+        scraper.download_file(zip_path)
+    else:
+        with tempfile.TemporaryDirectory() as destination:
+            index_copy_path = os.path.join(destination, 'index.html')
+            destination_src = os.path.join(destination, 'imscp')
 
-        with open(index_copy_path, 'w') as f:
-            f.write("""
-                <!DOCTYPE html>
-                <html>
-                <head>
-                <script type="text/javascript">
-                    window.location.replace('imscp/%s');
-                </script>
-                </head>
-                <body></body>
-                </html>
-            """ % content_dict['index_file'])
+            with open(index_copy_path, 'w') as f:
+                f.write("""
+                    <!DOCTYPE html>
+                    <html>
+                    <head>
+                    <script type="text/javascript">
+                        window.location.replace('imscp/%s');
+                    </script>
+                    </head>
+                    <body></body>
+                    </html>
+                """ % content_dict['index_file'])
 
-        copy_tree(ims_dir, destination_src)
+            copy_tree(ims_dir, destination_src)
+            zip_path = create_predictable_zip(destination)
+            #preview_in_browser(destination)
 
-        #preview_in_browser(destination)
-
-        zip_path = create_predictable_zip(destination)
-        return nodes.HTML5AppNode(
-            source_id=content_dict['identifier'],
-            title=content_dict.get('title'),
-            license=license,
-            files=[files.HTMLZipFile(zip_path)],
-        )
+    return nodes.HTML5AppNode(
+        source_id=content_dict['identifier'],
+        title=content_dict.get('title'),
+        license=license,
+        files=[files.HTMLZipFile(zip_path)],
+    )

--- a/ricecooker_utils.py
+++ b/ricecooker_utils.py
@@ -57,25 +57,15 @@ def create_html5_app_node(license, content_dict, ims_dir, scraper_class=None,
         scraper.download_file(zip_path)
     else:
         with tempfile.TemporaryDirectory() as destination:
-            index_copy_path = os.path.join(destination, 'index.html')
-            destination_src = os.path.join(destination, 'imscp')
+            index_src_path = os.path.join(ims_dir, content_dict['index_file'])
+            index_dest_path = os.path.join(destination, 'index.html')
+            shutil.copyfile(index_src_path, index_dest_path)
 
-            with open(index_copy_path, 'w') as f:
-                f.write("""
-                    <!DOCTYPE html>
-                    <html>
-                    <head>
-                    <script type="text/javascript">
-                        window.location.replace('imscp/%s');
-                    </script>
-                    </head>
-                    <body></body>
-                    </html>
-                """ % content_dict['index_file'])
+            for file_path in content_dict['files']:
+                shutil.copy(os.path.join(ims_dir, file_path), destination)
 
-            copy_tree(ims_dir, destination_src)
-            zip_path = create_predictable_zip(destination)
             #preview_in_browser(destination)
+            zip_path = create_predictable_zip(destination)
 
     return nodes.HTML5AppNode(
         source_id=content_dict['identifier'],


### PR DESCRIPTION
Test run:

```
PYTHONPATH=. examples/gitta_chef.py -v --token=yourtoken --reset
```

See that zip files uploaded are much smaller (~200KB vs ~5MB).

View on Studio: 

https://api.studio.learningequality.org/channels/3a9b468b3c5d544c90105ce47bcc5a09/edit/00fc279

Note that this requires [this pending PR](https://github.com/learningequality/webmixer/pull/3) to be merged into Webmixer, and also [this small change](https://github.com/learningequality/webmixer/pull/5) to get webmixer to work for local `file://` files.