### PR TITLE
Add support for xml:base attributes

### DIFF
--- a/src/imscp/core.py
+++ b/src/imscp/core.py
@@ -164,7 +164,7 @@ def derive_content_files_dict(resource_elem, resources_dict, ims_dir):
     nsmap = resource_elem.nsmap
     file_elements = resource_elem.findall('file', nsmap)
     base = "./" + resource_elem.get('{http://www.w3.org/XML/1998/namespace}base') or ""
-    file_paths = [base + fe.get('href') for fe in file_elements if not fe.get('href').endswith('.')]
+    file_paths = [base + fe.get('href') for fe in file_elements]
     dep_elements = resource_elem.findall('dependency', nsmap)
     dep_res_elements = (resources_dict[de.get('identifierref')] for de in dep_elements)
     dep_paths_list = (derive_content_files_dict(dre, resources_dict, ims_dir)

--- a/src/imscp/core.py
+++ b/src/imscp/core.py
@@ -163,7 +163,8 @@ def collect_resources(license, item, resources_dict, ims_dir):
 def derive_content_files_dict(resource_elem, resources_dict, ims_dir):
     nsmap = resource_elem.nsmap
     file_elements = resource_elem.findall('file', nsmap)
-    file_paths = [fe.get('href') for fe in file_elements]
+    base = "./" + resource_elem.get('{http://www.w3.org/XML/1998/namespace}base') or ""
+    file_paths = [base + fe.get('href') for fe in file_elements if not fe.get('href').endswith('.')]
     dep_elements = resource_elem.findall('dependency', nsmap)
     dep_res_elements = (resources_dict[de.get('identifierref')] for de in dep_elements)
     dep_paths_list = (derive_content_files_dict(dre, resources_dict, ims_dir)

--- a/src/imscp/core.py
+++ b/src/imscp/core.py
@@ -163,7 +163,7 @@ def collect_resources(license, item, resources_dict, ims_dir):
 def derive_content_files_dict(resource_elem, resources_dict, ims_dir):
     nsmap = resource_elem.nsmap
     file_elements = resource_elem.findall('file', nsmap)
-    base = "./" + resource_elem.get('{http://www.w3.org/XML/1998/namespace}base') or ""
+    base = "./" + (resource_elem.get('{http://www.w3.org/XML/1998/namespace}base') or "")
     file_paths = [base + fe.get('href') for fe in file_elements]
     dep_elements = resource_elem.findall('dependency', nsmap)
     dep_res_elements = (resources_dict[de.get('identifierref')] for de in dep_elements)


### PR DESCRIPTION
This fixes https://github.com/learningequality/ricecooker/issues/298

This is attempting to help with https://github.com/learningequality/studio/issues/2523 - it works to find files which have a xml:base resource reference.